### PR TITLE
add parseDate helper to fix edge case

### DIFF
--- a/service/pins.js
+++ b/service/pins.js
@@ -189,8 +189,8 @@ const match = (query, { pin, status, created }) => {
     (query.cid == null || cids.includes(pin.cid)) &&
     (query.name == null || query.name == pin.name) &&
     (query.status == null || statuses.includes(status)) &&
-    (query.before == null || Date.parse(created) < Date.parse(query.before)) &&
-    (query.after == null || Date.parse(created) > Date.parse(query.after)) &&
+    (query.before == null || parseDate(created) < parseDate(query.before)) &&
+    (query.after == null || parseDate(created) > parseDate(query.after)) &&
     (query.meta == null || matchMetadata(query.meta, pin.meta || {}))
 
   return matched
@@ -227,6 +227,22 @@ const deriveStatus = ({ name = "" }) => {
   }
 
   return STATUS.queued
+}
+
+/**
+ * Parse the input using Date.parse, with special casing if the input is already a Date.
+ * 
+ * @param {Date|string} d - a Date object or ISO-formatted date string.
+ * @returns {number} - the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC
+ */
+const parseDate = (d) => {
+  if (d instanceof Date) {
+    // Calling Date.parse on a Date instance causes the milliseconds to be thrown away,
+    // so e.g. a date representing 1616522896307 becomes 1616522896000.
+    // Calling toISOString and parsing _that_ seems to work. 
+    return Date.parse(d.toISOString())
+  }
+  return Date.parse(d)
 }
 
 /**

--- a/service/pins.js
+++ b/service/pins.js
@@ -233,14 +233,11 @@ const deriveStatus = ({ name = "" }) => {
  * Parse the input using Date.parse, with special casing if the input is already a Date.
  * 
  * @param {Date|string} d - a Date object or ISO-formatted date string.
- * @returns {number} - the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC
+ * @returns {number|Date} - the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC, or a Date instance
  */
 const parseDate = (d) => {
-  if (d instanceof Date) {
-    // Calling Date.parse on a Date instance causes the milliseconds to be thrown away,
-    // so e.g. a date representing 1616522896307 becomes 1616522896000.
-    // Calling toISOString and parsing _that_ seems to work. 
-    return Date.parse(d.toISOString())
+  if (d instanceof Date) { 
+    return d
   }
   return Date.parse(d)
 }


### PR DESCRIPTION
@Gozala I'm writing tests for my js pinning client and hit this, since my test pins are all created within a few ms of each other.

Apparently calling `Date.parse(anExistingDateInstance)` will throw away the milliseconds part of the input `Date`. It also seems like by the time the `match` function is called, something has already converted the `query.before` and `query.after` params to `Date` objects.

This adds a `parseDate` helper to check if we've already got a `Date` and cast it to an ISO string before calling `Date.parse()`.

Thanks javascript...