### PR TITLE
include api/oas-doc.yaml in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist",
     "service",
+    "api",
     "*.js",
     "*.ts"
   ],


### PR DESCRIPTION
I was getting errors like this when using the latest version:

```
[Error: ENOENT: no such file or directory, open '/Users/yusef/work/wip/test-mock-service/node_modules/mock-ipfs-pinning-service/api/oas-doc.yaml'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/yusef/work/wip/test-mock-service/node_modules/mock-ipfs-pinning-service/api/oas-doc.yaml'
}
```

This PR just adds the `api` dir to the `files` list in package.json. Hopefully that will sort things out.