### PR TITLE
fix: use .load instead of .safeLoad

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const setup = async ({
     path.join(__dirname, "/api/oas-doc.yaml"),
     "utf8"
   )
-  const oasDoc = jsyaml.safeLoad(spec)
+  const oasDoc = jsyaml.load(spec)
 
   const app = express()
   app.use(cors())


### PR DESCRIPTION
Fixes errors like:

```
Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```