### PR TITLE
fix: running via npx 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist",
     "service",
+    "controllers",
     "api",
     "*.js",
     "*.ts"


### PR DESCRIPTION
I believe this should fix #16. From what I can tell problem was that `controllers` dir was omitted when publishing to npm which was then required when running a service.