### PR TITLE
docs(usage): Use express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const main = async () => {
   // Express server cleanup handling.
   const cleanup = () => {
     server.close((err) => {
-      if (!err || !err?.code === 'ERR_SERVER_NOT_RUNNING') {
+      if (!err || err?.code !== 'ERR_SERVER_NOT_RUNNING') {
         console.log(`server stopped listening on port ${port}`)
       }
       if (err) {

--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@ Implementation of in-memory [IPFS Pinning Service API](https://ipfs.github.io/pi
 ## Install
 
 ```
-npm i mock-ipfs-pinning-service
+npm i -D mock-ipfs-pinning-service @types/express
 ```
 
 ## Usage
 
 ```js
-const http = require("http")
 const { setup } = require("mock-ipfs-pinning-service")
 const port = 3000
 
 const main = async () => {
-  const service = await setup({ token: "secret" })
-  const server = http.createServer(http)
+  /**
+   * @type {import('express').Application}
+   */
+  const server = await setup({ token: "secret" })
   server.listen(port)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const main = async () => {
    */
   const server = await setup({ token: "secret" })
   server.listen(port, () => {
-    console.log(`server running on port ${port}`);
+    console.log(`server running on port ${port}`)
   })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ const main = async () => {
    * @type {import('express').Application}
    */
   const server = await setup({ token: "secret" })
-  server.listen(port)
+  server.listen(port, () => {
+    console.log(`server running on port ${port}`);
+  })
 }
 ```
 


### PR DESCRIPTION
The original instructions were outdated and incorrect and started up two servers: one express server inside the mock-ipfs-pinning-service's `setup` call, and one via http.

This resulted in any requests going to the http server, which has no logic/code behind it and would timeout on requests.